### PR TITLE
fix: use the new `configuredFor` method in all places

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
 
         <!-- Dependency versions -->
         <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
+        <freemarker.version>2.3.32</freemarker.version>
 
         <!-- Plugin versions -->
         <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
@@ -94,6 +95,12 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-services</artifactId>
             <version>${keycloak.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.freemarker</groupId>
+            <artifactId>freemarker</artifactId>
+            <version>${freemarker.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/ch/jacem/for_keycloak/email_otp_authenticator/forms/login/freemarker/CustomAuthenticatorConfiguredMethod.java
+++ b/src/main/java/ch/jacem/for_keycloak/email_otp_authenticator/forms/login/freemarker/CustomAuthenticatorConfiguredMethod.java
@@ -1,0 +1,36 @@
+package ch.jacem.for_keycloak.email_otp_authenticator.forms.login.freemarker;
+
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModelException;
+
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.KeycloakSession;
+
+import ch.jacem.for_keycloak.email_otp_authenticator.authentication.authenticators.conditional.AcceptsFullContextInConfiguredFor;
+
+import java.util.List;
+
+public class CustomAuthenticatorConfiguredMethod implements TemplateMethodModelEx {
+    private final AuthenticationFlowContext context;
+    private final AuthenticatorConfigModel config;
+
+    public CustomAuthenticatorConfiguredMethod(AuthenticationFlowContext context, AuthenticatorConfigModel config) {
+        this.context = context;
+        this.config = config;
+    }
+
+    @Override
+    public Object exec(List list) throws TemplateModelException {
+        String providerId = list.get(0).toString();
+        KeycloakSession session = this.context.getSession();
+        Authenticator authenticator = session.getProvider(Authenticator.class, providerId);
+
+        if (authenticator instanceof AcceptsFullContextInConfiguredFor) {
+            return ((AcceptsFullContextInConfiguredFor) authenticator).configuredFor(context, config);
+        }
+
+        return authenticator.configuredFor(session, this.context.getRealm(), this.context.getUser());
+    }
+}

--- a/src/main/java/ch/jacem/for_keycloak/email_otp_authenticator/forms/login/freemarker/CustomFreeMarkerLoginFormsProvider.java
+++ b/src/main/java/ch/jacem/for_keycloak/email_otp_authenticator/forms/login/freemarker/CustomFreeMarkerLoginFormsProvider.java
@@ -1,0 +1,34 @@
+package ch.jacem.for_keycloak.email_otp_authenticator.forms.login.freemarker;
+
+import org.keycloak.forms.login.LoginFormsPages;
+import org.keycloak.forms.login.freemarker.FreeMarkerLoginFormsProvider;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.theme.Theme;
+
+import jakarta.ws.rs.core.UriBuilder;
+
+import java.util.Locale;
+import java.util.Properties;
+
+public class CustomFreeMarkerLoginFormsProvider extends FreeMarkerLoginFormsProvider {
+    public CustomFreeMarkerLoginFormsProvider(KeycloakSession session) {
+        super(session);
+    }
+
+    @Override
+    protected void createCommonAttributes(Theme theme, Locale locale, Properties messagesBundle, UriBuilder baseUriBuilder, LoginFormsPages page) {
+        super.createCommonAttributes(theme, locale, messagesBundle, baseUriBuilder, page);
+
+        if (attributes.containsKey("authenticatorConfigured") && null != this.context && null != this.realm && null != this.execution) {
+            // Get configuration
+            AuthenticationExecutionModel executionModel = this.realm.getAuthenticationExecutionById(this.execution);
+            if (null == executionModel) return;
+            AuthenticatorConfigModel configModel = this.realm.getAuthenticatorConfigById(executionModel.getAuthenticatorConfig());
+            if (null == configModel) return;
+
+            attributes.put("authenticatorConfigured", new CustomAuthenticatorConfiguredMethod(this.context, configModel));
+        }
+    }
+}

--- a/src/main/java/ch/jacem/for_keycloak/email_otp_authenticator/forms/login/freemarker/CustomFreeMarkerLoginFormsProviderFactory.java
+++ b/src/main/java/ch/jacem/for_keycloak/email_otp_authenticator/forms/login/freemarker/CustomFreeMarkerLoginFormsProviderFactory.java
@@ -1,0 +1,12 @@
+package ch.jacem.for_keycloak.email_otp_authenticator.forms.login.freemarker;
+
+import org.keycloak.forms.login.LoginFormsProvider;
+import org.keycloak.forms.login.freemarker.FreeMarkerLoginFormsProviderFactory;
+import org.keycloak.models.KeycloakSession;
+
+public class CustomFreeMarkerLoginFormsProviderFactory extends FreeMarkerLoginFormsProviderFactory {
+    @Override
+    public LoginFormsProvider create(KeycloakSession session) {
+        return new CustomFreeMarkerLoginFormsProvider(session);
+    }
+}

--- a/src/main/resources/META-INF/services/org.keycloak.forms.login.LoginFormsProviderFactory
+++ b/src/main/resources/META-INF/services/org.keycloak.forms.login.LoginFormsProviderFactory
@@ -1,0 +1,1 @@
+ch.jacem.for_keycloak.email_otp_authenticator.forms.login.freemarker.CustomFreeMarkerLoginFormsProviderFactory


### PR DESCRIPTION
A know bug is that when you have another ALTERNATIVE configured execution, the email OTP will always show in the list of "other ways" to login. It will not execute or be required, but it will be shown.

This is because internal keycloak classes use the "normal" `configuredFor` method which does not take into consideration the flow configuration.

These uses were spotted in (✅ means fixed, either in this pr or in main & ❌ means not yet fixed):
- ✅ https://github.com/keycloak/keycloak/blob/579b185e7af60d741c97a1c73e975506b0c1e56c/services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalUserConfiguredAuthenticator.java#L61
- ✅ https://github.com/keycloak/keycloak/blob/579b185e7af60d741c97a1c73e975506b0c1e56c/services/src/main/java/org/keycloak/forms/login/freemarker/AuthenticatorConfiguredMethod.java#L46
- ❌ https://github.com/keycloak/keycloak/blob/579b185e7af60d741c97a1c73e975506b0c1e56c/services/src/main/java/org/keycloak/authentication/DefaultAuthenticationFlow.java#L458
- ❌ https://github.com/keycloak/keycloak/blob/579b185e7af60d741c97a1c73e975506b0c1e56c/services/src/main/java/org/keycloak/authentication/FormAuthenticationFlow.java#L197