### PR TITLE
chore(keycloak): update default version references from 26.5.2 to 26.5.3

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         keycloak_version:
-          - keycloak-26.5.2
+          - keycloak-26.5.3
           - keycloak-26.4.7
           - keycloak-26.3.5
           - keycloak-26.2.5

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,7 +40,7 @@ jobs:
           - '26.2.5'
           - '26.3.5'
           - '26.4.7'
-          - '26.5.2'
+          - '26.5.3'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Add the following to your Dockerfile:
 ```dockerfile
 # Download and install the authenticator
 ARG EMAIL_OTP_AUTHENTICATOR_VERSION="v1.3.2" # x-release-please-version
-ARG EMAIL_OTP_AUTHENTICATOR_KC_VERSION="26.5.2"
+ARG EMAIL_OTP_AUTHENTICATOR_KC_VERSION="26.5.3"
 ADD https://github.com/for-keycloak/email-otp-authenticator/releases/download/${EMAIL_OTP_AUTHENTICATOR_VERSION}/email-otp-authenticator-${EMAIL_OTP_AUTHENTICATOR_VERSION}-kc-${EMAIL_OTP_AUTHENTICATOR_KC_VERSION}.jar \
     /opt/keycloak/providers/email-otp-authenticator.jar
 ```
@@ -115,7 +115,7 @@ ADD https://github.com/for-keycloak/email-otp-authenticator/releases/download/${
 
 Using just:
 ```bash
-# Build for the default Keycloak version (26.5.2)
+# Build for the default Keycloak version (26.5.3)
 just build
 
 # Build for a specific Keycloak version
@@ -158,7 +158,7 @@ Access:
 
 The authenticator is built and tested with multiple Keycloak versions:
 
-- 26.5.2 (default)
+- 26.5.3 (default)
 - 26.4.7
 - 26.3.5
 - 26.2.5

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ./target/email-otp-authenticator-dev-kc-26.5.2.jar:/opt/keycloak/providers/email-otp-authenticator.jar
+      - ./target/email-otp-authenticator-dev-kc-26.5.3.jar:/opt/keycloak/providers/email-otp-authenticator.jar
     command: start-dev
     depends_on:
       - mailpit

--- a/justfile
+++ b/justfile
@@ -44,13 +44,13 @@ shell:
 # List all available Keycloak versions
 versions:
     @echo "Supported Keycloak versions:"
-    @echo "- 26.5.2 (default)"
+    @echo "- 26.5.3 (default)"
     @echo "- 26.4.7"
     @echo "- 26.3.5"
     @echo "- 26.2.5"
 
 # Run E2E tests (optionally specify a file pattern, requires test-e2e-setup if FILE is provided)
-test-e2e KC_VERSION="26.5.2" FILE="": (build-version KC_VERSION)
+test-e2e KC_VERSION="26.5.3" FILE="": (build-version KC_VERSION)
     #!/usr/bin/env bash
     cd tests/e2e
     if [ -z "{{FILE}}" ]; then
@@ -62,7 +62,7 @@ test-e2e KC_VERSION="26.5.2" FILE="": (build-version KC_VERSION)
     fi
 
 # Start test infrastructure only (for debugging or running specific tests)
-test-e2e-setup KC_VERSION="26.5.2": (build-version KC_VERSION)
+test-e2e-setup KC_VERSION="26.5.3": (build-version KC_VERSION)
     cd tests/e2e && KC_VERSION={{KC_VERSION}} docker compose up -d --wait
 
 # Stop test containers

--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
     <!-- Profiles for different Keycloak versions -->
     <profiles>
         <profile>
-            <id>keycloak-26.5.2</id>
-            <properties><keycloak.version>26.5.2</keycloak.version></properties>
+            <id>keycloak-26.5.3</id>
+            <properties><keycloak.version>26.5.3</keycloak.version></properties>
             <activation><activeByDefault>true</activeByDefault></activation>
         </profile>
         <profile>

--- a/tests/e2e/docker-compose.yaml
+++ b/tests/e2e/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       - test
 
   keycloak:
-    image: quay.io/keycloak/keycloak:${KC_VERSION:-26.5.2}
+    image: quay.io/keycloak/keycloak:${KC_VERSION:-26.5.3}
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
@@ -35,7 +35,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ../../target/email-otp-authenticator-dev-kc-${KC_VERSION:-26.5.2}.jar:/opt/keycloak/providers/email-otp-authenticator.jar
+      - ../../target/email-otp-authenticator-dev-kc-${KC_VERSION:-26.5.3}.jar:/opt/keycloak/providers/email-otp-authenticator.jar
     command: start-dev
     depends_on:
       postgres:


### PR DESCRIPTION
## Summary

Updates all remaining references of Keycloak `26.5.2` to `26.5.3` to align with the dependency bump already applied in `pom.xml`.


## Changes

- **README.md** - Dockerfile example, build comment, supported versions list
- **pom.xml** - Maven profile id and version
- **justfile** - versions list and default parameters for `test-e2e` / `test-e2e-setup`
- **docker-compose.yaml** - JAR volume mount path
- **tests/e2e/docker-compose.yaml** - Default image tag and JAR path
- **.github/workflows/release-please.yaml** - Build matrix
- **.github/workflows/tests.yaml** - E2E test matrix
