### PR TITLE
feat: expose realm in the FreeMarker model for OTP email templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,20 @@ The authenticator sets different ACR values based on how authentication was comp
 These ACR values can be used by applications to understand the authentication strength and make authorization decisions accordingly.
 
 
+## Customizing the OTP email template
+
+The plugin sends the OTP email through Keycloak's standard `EmailTemplateProvider` using the FreeMarker template `otp-email.ftl` (both `html/` and `text/` variants are supported). You can override these templates in your own email theme.
+
+The FreeMarker model exposes the following variables on top of what Keycloak adds by default (`user`, `realmName`, `url`, `msg`, `properties`, `locale`):
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `otp` | `String` | The generated one-time code |
+| `ttl` | `int` | Code lifetime in seconds |
+| `ttlMinutes` | `int` | Code lifetime in minutes (`ttl / 60`) |
+| `realm` | `RealmModel` | The current realm. Useful to read realm-level attributes for branding (e.g., `${realm.attributes['_brandPrimary']!'#000'}`), mirroring what login templates have access to. |
+
+
 ## Installation
 
 ### Option 1: Using Docker

--- a/src/main/java/ch/jacem/for_keycloak/email_otp_authenticator/EmailOTPFormAuthenticator.java
+++ b/src/main/java/ch/jacem/for_keycloak/email_otp_authenticator/EmailOTPFormAuthenticator.java
@@ -625,6 +625,9 @@ public class EmailOTPFormAuthenticator extends AbstractUsernameFormAuthenticator
             attributes.put("otp", otp);
             attributes.put("ttl", ttlSeconds);
             attributes.put("ttlMinutes", ttlSeconds / 60);
+            // Expose the realm so templates can read realm-level attributes
+            // (mirrors what login templates have access to).
+            attributes.put("realm", context.getRealm());
 
             context.getSession()
                 .getProvider(EmailTemplateProvider.class)


### PR DESCRIPTION
Adds the current realm to the attributes map passed to the email template provider, so templates can read realm-level attributes (colors, logo URLs, custom data) to brand the OTP email body without forking the plugin or writing a custom EmailTemplateProvider SPI.

Mirrors the access pattern login templates already enjoy via the standard RealmBean.

Non-breaking: adds a new variable, does not modify existing ones.

## Description

Exposes `context.getRealm()` as the `realm` variable in the FreeMarker model used to render the OTP email. Templates can then read realm-level attributes the same way login templates do:

```ftl
<#assign primary = realm.attributes['_brandPrimary']!'#000'>
<#assign logo    = realm.attributes['_brandLogoUrl']!''>
```

The README has a new "Customizing the OTP email template" section that documents every variable available in the model (`otp`, `ttl`, `ttlMinutes`, `realm`) on top of the standard Keycloak ones (`user`, `realmName`, `url`, `msg`, `properties`, `locale`).


## Related Issue

Closes #70. Related context: #69 (form template scope, not addressed here).


## Checklist

- [x] Code is tested and works as expected.
- [x] Documentation is updated (if applicable).
- [x] No linting or formatting issues.


## Screenshots (if applicable)

N/A — the change exposes a variable to templates, no visible behavior on its own.


## Additional Notes

**Testing**

- All existing unit tests pass: `mvn test` → 273 / 0 / 0.
- End-to-end smoke test on Keycloak 26.5 with a custom email theme that reads `realm.attributes['_brandPalettePrimary']` and `realm.attributes['_brandAssetsLogoPrimary']`: branded OTP email delivered as expected, fallback path verified by unsetting the attributes.

**Scope**

This PR only touches `EmailOTPFormAuthenticator#sendOtpEmail`. The OTP form template (`login-email-otp.ftl`) is not modified — the request from #69 is a separate concern and would be a follow-up.
