### PR TITLE
chore(keycloak): add 26.6.2 (default), 26.5.7; bump default from 26.5.4

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -33,7 +33,8 @@ jobs:
       fail-fast: false
       matrix:
         keycloak_version:
-          - keycloak-26.5.4
+          - keycloak-26.6.2
+          - keycloak-26.5.7
           - keycloak-26.4.7
           - keycloak-26.3.5
           - keycloak-26.2.5

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,7 +40,8 @@ jobs:
           - '26.2.5'
           - '26.3.5'
           - '26.4.7'
-          - '26.5.4'
+          - '26.5.7'
+          - '26.6.2'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Add the following to your Dockerfile:
 ```dockerfile
 # Download and install the authenticator
 ARG EMAIL_OTP_AUTHENTICATOR_VERSION="v1.3.5" # x-release-please-version
-ARG EMAIL_OTP_AUTHENTICATOR_KC_VERSION="26.5.4"
+ARG EMAIL_OTP_AUTHENTICATOR_KC_VERSION="26.6.2"
 ADD https://github.com/for-keycloak/email-otp-authenticator/releases/download/${EMAIL_OTP_AUTHENTICATOR_VERSION}/email-otp-authenticator-${EMAIL_OTP_AUTHENTICATOR_VERSION}-kc-${EMAIL_OTP_AUTHENTICATOR_KC_VERSION}.jar \
     /opt/keycloak/providers/email-otp-authenticator.jar
 ```
@@ -129,7 +129,7 @@ ADD https://github.com/for-keycloak/email-otp-authenticator/releases/download/${
 
 Using just:
 ```bash
-# Build for the default Keycloak version (26.5.4)
+# Build for the default Keycloak version (26.6.2)
 just build
 
 # Build for a specific Keycloak version
@@ -172,7 +172,8 @@ Access:
 
 The authenticator is built and tested with multiple Keycloak versions:
 
-- 26.5.4 (default)
+- 26.6.2 (default)
+- 26.5.7
 - 26.4.7
 - 26.3.5
 - 26.2.5

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   keycloak:
-    image: quay.io/keycloak/keycloak:26.5.4
+    image: quay.io/keycloak/keycloak:26.6.2
     environment:
       # Admin console credentials
       KEYCLOAK_ADMIN: admin
@@ -19,7 +19,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ./target/email-otp-authenticator-dev-kc-26.5.4.jar:/opt/keycloak/providers/email-otp-authenticator.jar
+      - ./target/email-otp-authenticator-dev-kc-26.6.2.jar:/opt/keycloak/providers/email-otp-authenticator.jar
     command: start-dev
     depends_on:
       - mailpit
@@ -31,7 +31,7 @@ services:
       - "1025:1025" # SMTP Server
 
   postgres:
-    image: postgres:18.3
+    image: postgres:18.4
     volumes:
       - postgres-data:/var/lib/postgresql/data
     environment:

--- a/justfile
+++ b/justfile
@@ -44,13 +44,14 @@ shell:
 # List all available Keycloak versions
 versions:
     @echo "Supported Keycloak versions:"
-    @echo "- 26.5.4 (default)"
+    @echo "- 26.6.2 (default)"
+    @echo "- 26.5.7"
     @echo "- 26.4.7"
     @echo "- 26.3.5"
     @echo "- 26.2.5"
 
 # Run E2E tests (optionally specify a file pattern, requires test-e2e-setup if FILE is provided)
-test-e2e KC_VERSION="26.5.4" FILE="": (build-version KC_VERSION)
+test-e2e KC_VERSION="26.6.2" FILE="": (build-version KC_VERSION)
     #!/usr/bin/env bash
     cd tests/e2e
     if [ -z "{{FILE}}" ]; then
@@ -62,7 +63,7 @@ test-e2e KC_VERSION="26.5.4" FILE="": (build-version KC_VERSION)
     fi
 
 # Start test infrastructure only (for debugging or running specific tests)
-test-e2e-setup KC_VERSION="26.5.4": (build-version KC_VERSION)
+test-e2e-setup KC_VERSION="26.6.2": (build-version KC_VERSION)
     cd tests/e2e && KC_VERSION={{KC_VERSION}} docker compose up -d --wait
 
 # Stop test containers

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <skipTests>true</skipTests>
 
         <!-- Default Keycloak version -->
-        <keycloak.version>26.5.4</keycloak.version>
+        <keycloak.version>26.6.2</keycloak.version>
 
         <!-- Dependency versions -->
         <jakarta.ws.rs-api.version>4.0.0</jakarta.ws.rs-api.version>
@@ -58,9 +58,13 @@
     <!-- Profiles for different Keycloak versions -->
     <profiles>
         <profile>
-            <id>keycloak-26.5.4</id>
-            <properties><keycloak.version>26.5.4</keycloak.version></properties>
+            <id>keycloak-26.6.2</id>
+            <properties><keycloak.version>26.6.2</keycloak.version></properties>
             <activation><activeByDefault>true</activeByDefault></activation>
+        </profile>
+        <profile>
+            <id>keycloak-26.5.7</id>
+            <properties><keycloak.version>26.5.7</keycloak.version></properties>
         </profile>
         <profile>
             <id>keycloak-26.4.7</id>

--- a/tests/e2e/docker-compose.yaml
+++ b/tests/e2e/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       - test
 
   keycloak:
-    image: quay.io/keycloak/keycloak:${KC_VERSION:-26.5.4}
+    image: quay.io/keycloak/keycloak:${KC_VERSION:-26.6.2}
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
@@ -35,7 +35,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ../../target/email-otp-authenticator-dev-kc-${KC_VERSION:-26.5.4}.jar:/opt/keycloak/providers/email-otp-authenticator.jar
+      - ../../target/email-otp-authenticator-dev-kc-${KC_VERSION:-26.6.2}.jar:/opt/keycloak/providers/email-otp-authenticator.jar
     command: start-dev
     depends_on:
       postgres:


### PR DESCRIPTION
## Description

Expands the build matrix to track every supported Keycloak 26.x minor at its latest patch:

- **adds** `keycloak-26.6.2` profile as the new default (was `keycloak-26.5.4`)
- **adds** `keycloak-26.5.7` (latest 26.5 patch)
- `keycloak-26.4.7`, `keycloak-26.3.5`, `keycloak-26.2.5` already at their latest patch - unchanged

Files touched:

- `pom.xml` - default `<keycloak.version>` to `26.6.2`; adds two profiles (`keycloak-26.6.2` as `activeByDefault`, `keycloak-26.5.7`)
- `.github/workflows/tests.yaml` and `.github/workflows/release-please.yaml` - matrices extended to 5 entries
- `docker-compose.yaml` - `keycloak:26.6.2`, shaded JAR path; **also bumps `postgres:18.3` -> `postgres:18.4`** (absorbs #72)
- `tests/e2e/docker-compose.yaml` - `${KC_VERSION:-...}` defaults
- `justfile` - `versions` recipe and `test-e2e` / `test-e2e-setup` `KC_VERSION` defaults
- `README.md` - Dockerfile snippet, build instructions, supported-versions list

This supersedes the dependabot PRs **#72** (docker-compose `keycloak:26.6.1` + `postgres:18.4`) and **#73** (Maven default `keycloak.version` 26.5.4 -> 26.6.2). Once this merges they should auto-close on the next dependabot scan.


## Related Issue

Supersedes #72, #73.


## Checklist

- [x] Code is tested and works as expected.
- [x] Documentation is updated (if applicable).
- [x] No linting or formatting issues.


## Screenshots (if applicable)

N/A.


## Additional Notes

**Local validation (via `just`):**

- `just build` (default profile, now `26.6.2`) -> BUILD SUCCESS
- `just build-version 26.5.7` (new profile) -> BUILD SUCCESS
- `just build-version 26.2.5` (compatibility floor) -> BUILD SUCCESS
- `just test` -> **273 / 0 / 0**

CI will exercise all five profiles via the extended e2e matrix.
