### PR TITLE
feat(form): expose email and maskedEmail attributes on the OTP form

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ The FreeMarker model exposes the following variables on top of what Keycloak add
 | `realm` | `RealmModel` | The current realm. Useful to read realm-level attributes for branding (e.g., `${realm.attributes['_brandPrimary']!'#000'}`), mirroring what login templates have access to. |
 
 
+## Customizing the OTP entry form
+
+The OTP entry form is rendered from the FreeMarker template `login-email-otp.ftl`. You can override it in your own login theme. On top of the standard Keycloak login template variables, the form receives:
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `email` | `String` | The recipient's email address. |
+| `maskedEmail` | `String` | The recipient's email with the local part and pre-TLD domain part masked, e.g. `jo***@gm***.com`. Useful for showing the destination on the form without leaking the full address. |
+
+Both are set only when the authenticated user has a non-empty email; templates should guard with FreeMarker defaults (e.g. `${maskedEmail!''}`) to stay safe.
+
+
 ## Installation
 
 ### Option 1: Using Docker

--- a/src/main/java/ch/jacem/for_keycloak/email_otp_authenticator/EmailOTPFormAuthenticator.java
+++ b/src/main/java/ch/jacem/for_keycloak/email_otp_authenticator/EmailOTPFormAuthenticator.java
@@ -496,6 +496,17 @@ public class EmailOTPFormAuthenticator extends AbstractUsernameFormAuthenticator
             }
         }
 
+        // Expose the recipient email and a masked variant so the form can
+        // show where the OTP was sent (e.g. "Code sent to jo***@gm***.com").
+        UserModel formUser = context.getUser();
+        if (formUser != null) {
+            String formEmail = formUser.getEmail();
+            if (formEmail != null && !formEmail.isEmpty()) {
+                form.setAttribute("email", formEmail);
+                form.setAttribute("maskedEmail", maskEmail(formEmail));
+            }
+        }
+
         // Add device trust info to form if enabled
         boolean deviceTrustEnabled = ConfigHelper.isDeviceTrustEnabled(context);
         form.setAttribute("deviceTrustEnabled", deviceTrustEnabled);
@@ -649,6 +660,43 @@ public class EmailOTPFormAuthenticator extends AbstractUsernameFormAuthenticator
                 this.buildOtpForm(context, Messages.EMAIL_SENT_ERROR, null)
             );
         }
+    }
+
+    /**
+     * Masks an email address for safe display in the OTP form. Keeps the first
+     * two characters of the local part and of the domain (excluding TLD),
+     * replacing the rest with "***". The TLD is preserved when the domain
+     * contains a dot. Example: "john.doe@gmail.com" -> "jo***@gm***.com".
+     * Malformed input (null, empty, missing "@", empty local or domain) is
+     * returned unchanged.
+     */
+    private static String maskEmail(String email) {
+        if (email == null || email.isEmpty()) {
+            return email;
+        }
+        int atIndex = email.indexOf('@');
+        if (atIndex < 0) {
+            return email;
+        }
+        String local = email.substring(0, atIndex);
+        String domain = email.substring(atIndex + 1);
+        if (local.isEmpty() || domain.isEmpty()) {
+            return email;
+        }
+
+        String maskedLocal = local.substring(0, Math.min(2, local.length())) + "***";
+
+        String maskedDomain;
+        int lastDotIndex = domain.lastIndexOf('.');
+        if (lastDotIndex < 0) {
+            maskedDomain = domain.substring(0, Math.min(2, domain.length())) + "***";
+        } else {
+            String preTld = domain.substring(0, lastDotIndex);
+            String tld = domain.substring(lastDotIndex + 1);
+            maskedDomain = preTld.substring(0, Math.min(2, preTld.length())) + "***." + tld;
+        }
+
+        return maskedLocal + "@" + maskedDomain;
     }
 
     private boolean isOtpExpired(AuthenticationFlowContext context) {

--- a/src/test/java/ch/jacem/for_keycloak/email_otp_authenticator/EmailOTPFormAuthenticatorTest.java
+++ b/src/test/java/ch/jacem/for_keycloak/email_otp_authenticator/EmailOTPFormAuthenticatorTest.java
@@ -373,4 +373,93 @@ class EmailOTPFormAuthenticatorTest {
             assertTrue(tenYearsInSeconds < 320_000_000);
         }
     }
+
+    @Nested
+    @DisplayName("Email Masking")
+    class EmailMasking {
+
+        @Test
+        @DisplayName("standard email is masked at local and pre-TLD domain parts")
+        void standardEmail() {
+            assertEquals("jo***@gm***.com", maskEmail("john.doe@gmail.com"));
+        }
+
+        @Test
+        @DisplayName("short local part is kept and suffixed with ***")
+        void shortLocalPart() {
+            assertEquals("a***@gm***.com", maskEmail("a@gmail.com"));
+        }
+
+        @Test
+        @DisplayName("subdomain is folded into the pre-TLD via last-dot split")
+        void subdomain() {
+            assertEquals("jo***@ma***.com", maskEmail("john@mail.example.com"));
+        }
+
+        @Test
+        @DisplayName("domain without a dot has no TLD preserved")
+        void domainWithoutDot() {
+            assertEquals("jo***@lo***", maskEmail("john@localhost"));
+        }
+
+        @Test
+        @DisplayName("email without @ is returned unchanged")
+        void missingAtSign() {
+            assertEquals("noatsign", maskEmail("noatsign"));
+        }
+
+        @Test
+        @DisplayName("empty string is returned unchanged")
+        void emptyString() {
+            assertEquals("", maskEmail(""));
+        }
+
+        @Test
+        @DisplayName("null is returned as null")
+        void nullEmail() {
+            assertNull(maskEmail(null));
+        }
+
+        @Test
+        @DisplayName("empty local part returns input unchanged")
+        void emptyLocalPart() {
+            assertEquals("@gmail.com", maskEmail("@gmail.com"));
+        }
+
+        @Test
+        @DisplayName("empty domain returns input unchanged")
+        void emptyDomain() {
+            assertEquals("john@", maskEmail("john@"));
+        }
+
+        // Mirrors the private method in EmailOTPFormAuthenticator.
+        private String maskEmail(String email) {
+            if (email == null || email.isEmpty()) {
+                return email;
+            }
+            int atIndex = email.indexOf('@');
+            if (atIndex < 0) {
+                return email;
+            }
+            String local = email.substring(0, atIndex);
+            String domain = email.substring(atIndex + 1);
+            if (local.isEmpty() || domain.isEmpty()) {
+                return email;
+            }
+
+            String maskedLocal = local.substring(0, Math.min(2, local.length())) + "***";
+
+            String maskedDomain;
+            int lastDotIndex = domain.lastIndexOf('.');
+            if (lastDotIndex < 0) {
+                maskedDomain = domain.substring(0, Math.min(2, domain.length())) + "***";
+            } else {
+                String preTld = domain.substring(0, lastDotIndex);
+                String tld = domain.substring(lastDotIndex + 1);
+                maskedDomain = preTld.substring(0, Math.min(2, preTld.length())) + "***." + tld;
+            }
+
+            return maskedLocal + "@" + maskedDomain;
+        }
+    }
 }


### PR DESCRIPTION
## Description

Closes #69. Exposes two new attributes on the OTP entry form (`login-email-otp.ftl`) so templates can show the user where the code was sent without leaking the full address:

- `email` - `String`, the recipient's email address
- `maskedEmail` - `String`, masked variant, e.g. `john.doe@gmail.com` -> `jo***@gm***.com`

The variables are exposed via `LoginFormsProvider.setAttribute(...)` in `buildOtpForm`, alongside the existing trust-related form attributes. They are set only when the authenticated user has a non-empty email - so the OTP-form rendering path is unaffected when the authenticator is skipped via `configuredFor`.

**Masking rule** (per maintainer's choice):

| Input | Output |
|-------|--------|
| `john.doe@gmail.com` | `jo***@gm***.com` |
| `a@gmail.com` | `a***@gm***.com` |
| `john@mail.example.com` | `jo***@ma***.com` (last-dot split, subdomain folded into pre-TLD) |
| `john@localhost` | `jo***@lo***` (no dot, no TLD preserved) |
| `null` / `""` / `noatsign` / `@gmail.com` / `john@` | returned unchanged (defensive) |

Implemented as a private static helper `maskEmail(String)` on `EmailOTPFormAuthenticator`, following the same convention as the existing `hashIpAddress` (tested via a mirror helper in the test class).


## Related Issue

Closes #69.


## Checklist

- [x] Code is tested and works as expected.
- [x] Documentation is updated (if applicable).
- [x] No linting or formatting issues.


## Screenshots (if applicable)

N/A - the change exposes variables to templates, no visible behavior on its own.


## Additional Notes

**Files changed:**
- `src/main/java/.../EmailOTPFormAuthenticator.java` - `form.setAttribute(...)` block in `buildOtpForm`; `maskEmail` static helper at end of class.
- `src/test/java/.../EmailOTPFormAuthenticatorTest.java` - new `@Nested` `EmailMasking` block (9 tests covering the rule plus null/empty/malformed inputs).
- `README.md` - new "Customizing the OTP entry form" section documenting the two new form variables.

**Local validation (via `just`):**

- `just test` -> **282 / 0 / 0** (273 prior + 9 new EmailMasking)
- `just build` (default profile) -> BUILD SUCCESS
- `just build-version 26.2.5` (compatibility floor) -> BUILD SUCCESS
