### PR TITLE
fix: report the otp reference category to engage brute-force protection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <maven-site-plugin.version>3.22.0</maven-site-plugin.version>
         <maven-project-info-reports-plugin.version>3.9.0</maven-project-info-reports-plugin.version>
+        <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
     </properties>
 
     <!-- Profiles for different Keycloak versions -->
@@ -61,6 +62,30 @@
             <id>keycloak-26.6.2</id>
             <properties><keycloak.version>26.6.2</keycloak.version></properties>
             <activation><activeByDefault>true</activeByDefault></activation>
+            <!-- Tests that depend on Keycloak 26.6+ APIs (e.g. DefaultBruteForceProtector.ALLOWED_AUTHENTICATION_CATEGORIES) live here and are only compiled on 26.6+ builds. -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>${build-helper-maven-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>add-kc26_6-test-source</id>
+                                <phase>generate-test-sources</phase>
+                                <goals>
+                                    <goal>add-test-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>src/test/java-kc26_6</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>keycloak-26.5.7</id>

--- a/src/main/java/ch/jacem/for_keycloak/email_otp_authenticator/EmailOTPFormAuthenticatorFactory.java
+++ b/src/main/java/ch/jacem/for_keycloak/email_otp_authenticator/EmailOTPFormAuthenticatorFactory.java
@@ -9,6 +9,7 @@ import org.keycloak.authentication.AuthenticatorFactory;
 import org.keycloak.models.AuthenticationExecutionModel.Requirement;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.credential.OTPCredentialModel;
 import org.keycloak.provider.ProviderConfigProperty;
 
 public class EmailOTPFormAuthenticatorFactory implements AuthenticatorFactory {
@@ -63,7 +64,11 @@ public class EmailOTPFormAuthenticatorFactory implements AuthenticatorFactory {
 
     @Override
     public String getReferenceCategory() {
-        return "otp-over-email";
+        // Must be one of the categories Keycloak's DefaultBruteForceProtector
+        // accepts (ALLOWED_AUTHENTICATION_CATEGORIES); otherwise failed OTP
+        // submissions are never counted and brute-force protection stays
+        // disengaged.
+        return OTPCredentialModel.TYPE;
     }
 
     @Override

--- a/src/test/java-kc26_6/ch/jacem/for_keycloak/email_otp_authenticator/EmailOTPFormAuthenticatorFactoryBruteForceCategoryTest.java
+++ b/src/test/java-kc26_6/ch/jacem/for_keycloak/email_otp_authenticator/EmailOTPFormAuthenticatorFactoryBruteForceCategoryTest.java
@@ -1,0 +1,26 @@
+package ch.jacem.for_keycloak.email_otp_authenticator;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.keycloak.services.managers.DefaultBruteForceProtector;
+
+// Scoped to the keycloak-26.6.2 profile via build-helper add-test-source (see pom.xml).
+// DefaultBruteForceProtector.ALLOWED_AUTHENTICATION_CATEGORIES was introduced in Keycloak 26.6,
+// so this source tree is only compiled/run on 26.6+ and is excluded from the older matrix builds,
+// where the category allow-list (and this whole mechanism) does not exist.
+@DisplayName("EmailOTPFormAuthenticatorFactory brute-force category (Keycloak 26.6+)")
+class EmailOTPFormAuthenticatorFactoryBruteForceCategoryTest {
+
+    @Test
+    @DisplayName("getReferenceCategory is in DefaultBruteForceProtector's allow-list")
+    void getReferenceCategoryIsAllowedForBruteForce() {
+        EmailOTPFormAuthenticatorFactory factory = new EmailOTPFormAuthenticatorFactory();
+
+        assertTrue(
+            DefaultBruteForceProtector.ALLOWED_AUTHENTICATION_CATEGORIES
+                .contains(factory.getReferenceCategory())
+        );
+    }
+}

--- a/src/test/java/ch/jacem/for_keycloak/email_otp_authenticator/EmailOTPFormAuthenticatorFactoryTest.java
+++ b/src/test/java/ch/jacem/for_keycloak/email_otp_authenticator/EmailOTPFormAuthenticatorFactoryTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.keycloak.authentication.Authenticator;
 import org.keycloak.models.AuthenticationExecutionModel.Requirement;
+import org.keycloak.models.credential.OTPCredentialModel;
 import org.keycloak.provider.ProviderConfigProperty;
 
 @DisplayName("EmailOTPFormAuthenticatorFactory")
@@ -39,9 +40,9 @@ class EmailOTPFormAuthenticatorFactoryTest {
         }
 
         @Test
-        @DisplayName("getReferenceCategory returns otp-over-email")
+        @DisplayName("getReferenceCategory returns the otp credential type")
         void getReferenceCategory() {
-            assertEquals("otp-over-email", factory.getReferenceCategory());
+            assertEquals(OTPCredentialModel.TYPE, factory.getReferenceCategory());
         }
 
         @Test

--- a/src/test/java/ch/jacem/for_keycloak/email_otp_authenticator/EmailOTPFormAuthenticatorFactoryTest.java
+++ b/src/test/java/ch/jacem/for_keycloak/email_otp_authenticator/EmailOTPFormAuthenticatorFactoryTest.java
@@ -12,6 +12,7 @@ import org.keycloak.authentication.Authenticator;
 import org.keycloak.models.AuthenticationExecutionModel.Requirement;
 import org.keycloak.models.credential.OTPCredentialModel;
 import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.services.managers.DefaultBruteForceProtector;
 
 @DisplayName("EmailOTPFormAuthenticatorFactory")
 class EmailOTPFormAuthenticatorFactoryTest {
@@ -43,6 +44,13 @@ class EmailOTPFormAuthenticatorFactoryTest {
         @DisplayName("getReferenceCategory returns the otp credential type")
         void getReferenceCategory() {
             assertEquals(OTPCredentialModel.TYPE, factory.getReferenceCategory());
+        }
+
+        @Test
+        @DisplayName("getReferenceCategory is counted by Keycloak's brute-force protection")
+        void getReferenceCategoryIsAllowedForBruteForce() {
+            assertTrue(DefaultBruteForceProtector.ALLOWED_AUTHENTICATION_CATEGORIES
+                .contains(factory.getReferenceCategory()));
         }
 
         @Test

--- a/src/test/java/ch/jacem/for_keycloak/email_otp_authenticator/EmailOTPFormAuthenticatorFactoryTest.java
+++ b/src/test/java/ch/jacem/for_keycloak/email_otp_authenticator/EmailOTPFormAuthenticatorFactoryTest.java
@@ -12,7 +12,6 @@ import org.keycloak.authentication.Authenticator;
 import org.keycloak.models.AuthenticationExecutionModel.Requirement;
 import org.keycloak.models.credential.OTPCredentialModel;
 import org.keycloak.provider.ProviderConfigProperty;
-import org.keycloak.services.managers.DefaultBruteForceProtector;
 
 @DisplayName("EmailOTPFormAuthenticatorFactory")
 class EmailOTPFormAuthenticatorFactoryTest {
@@ -49,8 +48,7 @@ class EmailOTPFormAuthenticatorFactoryTest {
         @Test
         @DisplayName("getReferenceCategory is counted by Keycloak's brute-force protection")
         void getReferenceCategoryIsAllowedForBruteForce() {
-            assertTrue(DefaultBruteForceProtector.ALLOWED_AUTHENTICATION_CATEGORIES
-                .contains(factory.getReferenceCategory()));
+            assertEquals("otp", factory.getReferenceCategory()); // value from DefaultBruteForceProtector.ALLOWED_AUTHENTICATION_CATEGORIES, not referenced directly because that constant only exists in Keycloak 26.6+ and we build against all supported versions (26.2.5+)
         }
 
         @Test

--- a/tests/e2e/setup/global-setup.ts
+++ b/tests/e2e/setup/global-setup.ts
@@ -4,6 +4,7 @@ import { setupTotpViaUI, closeBrowser, cleanupSecrets } from './totp-setup.js';
 
 const TEST_PASSWORD = 'testpassword';
 const OTP_ROLE = 'otp-required';
+const BRUTE_FORCE_FAILURE_FACTOR = 3;
 
 export default async function globalSetup() {
   try {
@@ -17,6 +18,7 @@ export default async function globalSetup() {
     await setupTrustWithAlternativesRealm();
     await setupShortTtlRealm();
     await setupI18nRealm();
+    await setupBruteForceRealm();
   } finally {
     await closeBrowser();
   }
@@ -646,4 +648,44 @@ async function setupI18nFlow(realmName: string) {
   await keycloakAdmin.bindBrowserFlow(realmName, flowAlias);
 }
 
-export { TEST_PASSWORD, OTP_ROLE };
+async function setupBruteForceRealm() {
+  const realmName = 'test-brute-force';
+
+  if (await keycloakAdmin.realmExists(realmName)) {
+    await keycloakAdmin.deleteRealm(realmName);
+  }
+
+  await keycloakAdmin.createRealm(realmName, {
+    bruteForceProtected: true,
+    failureFactor: BRUTE_FORCE_FAILURE_FACTOR,
+    waitIncrementSeconds: 60,
+    maxFailureWaitSeconds: 900,
+    maxDeltaTimeSeconds: 43200,
+    // Rapid test submissions must not trip the quick-login guard before
+    // failureFactor distinct failures have been counted
+    quickLoginCheckMilliSeconds: 0,
+  });
+  await keycloakAdmin.configureSmtp(realmName);
+  await keycloakAdmin.createTestClient(realmName);
+  await keycloakAdmin.createRole(realmName, OTP_ROLE);
+
+  const counterUserId = await keycloakAdmin.createUser(
+    realmName,
+    'counter-user',
+    'counter-user@test.local',
+    TEST_PASSWORD
+  );
+  await keycloakAdmin.assignRoleToUser(realmName, counterUserId, OTP_ROLE);
+
+  const lockoutUserId = await keycloakAdmin.createUser(
+    realmName,
+    'lockout-user',
+    'lockout-user@test.local',
+    TEST_PASSWORD
+  );
+  await keycloakAdmin.assignRoleToUser(realmName, lockoutUserId, OTP_ROLE);
+
+  await setupRequiredFlow(realmName);
+}
+
+export { TEST_PASSWORD, OTP_ROLE, BRUTE_FORCE_FAILURE_FACTOR };

--- a/tests/e2e/setup/keycloak-admin.ts
+++ b/tests/e2e/setup/keycloak-admin.ts
@@ -85,7 +85,7 @@ export class KeycloakAdmin {
     await this.request(`/${realmName}`, { method: 'DELETE' });
   }
 
-  async createRealm(realmName: string): Promise<void> {
+  async createRealm(realmName: string, overrides: Record<string, unknown> = {}): Promise<void> {
     const response = await this.request('', {
       method: 'POST',
       body: JSON.stringify({
@@ -99,6 +99,7 @@ export class KeycloakAdmin {
         bruteForceProtected: false,
         // Disable default required actions that could interfere with tests
         requiredActions: [],
+        ...overrides,
       }),
     });
 
@@ -653,6 +654,29 @@ export class KeycloakAdmin {
     }
     const users = await response.json();
     return users.length > 0 ? users[0] : null;
+  }
+
+  async getBruteForceStatus(
+    realmName: string,
+    userId: string
+  ): Promise<{ numFailures: number; disabled: boolean }> {
+    const response = await this.request(
+      `/${realmName}/attack-detection/brute-force/users/${userId}`
+    );
+    if (!response.ok) {
+      throw new Error(`Failed to get brute-force status: ${response.status}`);
+    }
+    return response.json();
+  }
+
+  async clearBruteForceStatus(realmName: string, userId: string): Promise<void> {
+    const response = await this.request(
+      `/${realmName}/attack-detection/brute-force/users/${userId}`,
+      { method: 'DELETE' }
+    );
+    if (!response.ok) {
+      throw new Error(`Failed to clear brute-force status: ${response.status}`);
+    }
   }
 
   async deleteAuthenticationFlow(

--- a/tests/e2e/specs/brute-force.spec.ts
+++ b/tests/e2e/specs/brute-force.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test';
+import { LoginPage } from '../helpers/login.js';
+import { OtpForm } from '../helpers/otp-form.js';
+import { mailpit } from '../setup/mailpit.js';
+import { keycloakAdmin } from '../setup/keycloak-admin.js';
+import { TEST_PASSWORD, BRUTE_FORCE_FAILURE_FACTOR } from '../setup/global-setup.js';
+
+const REALM = 'test-brute-force';
+const WRONG_CODE = 'WRONG1';
+
+// The brute-force protector processes failures on a background worker, so
+// the attack-detection counters can lag the HTTP response briefly. These
+// accessors are meant to be polled via expect.poll.
+function bruteForceStatusAccessors(userId: string) {
+  return {
+    numFailures: async () =>
+      (await keycloakAdmin.getBruteForceStatus(REALM, userId)).numFailures,
+    disabled: async () =>
+      (await keycloakAdmin.getBruteForceStatus(REALM, userId)).disabled,
+  };
+}
+
+test.describe('Brute-Force Protection', () => {
+  test.beforeEach(async () => {
+    // Clear emails before each test
+    await mailpit.deleteAllMessages();
+  });
+
+  test('each failed OTP submission increments the brute-force failure counter', async ({ page }) => {
+    const loginPage = new LoginPage(page);
+    const otpForm = new OtpForm(page);
+
+    const user = await keycloakAdmin.getUserByUsername(REALM, 'counter-user');
+    expect(user).not.toBeNull();
+    const status = bruteForceStatusAccessors(user!.id);
+
+    // Start from a clean slate so retries and repeated runs are deterministic
+    await keycloakAdmin.clearBruteForceStatus(REALM, user!.id);
+    await expect.poll(status.numFailures).toBe(0);
+    await expect.poll(status.disabled).toBe(false);
+
+    await loginPage.goto(REALM);
+    await loginPage.login('counter-user', TEST_PASSWORD);
+    await otpForm.expectVisible();
+
+    const email = await mailpit.waitForMessage('counter-user@test.local');
+    const code = mailpit.extractOtpCode(email);
+    expect(code).not.toBeNull();
+
+    // Stay below the lockout threshold so the account remains usable
+    for (let attempt = 1; attempt < BRUTE_FORCE_FAILURE_FACTOR; attempt++) {
+      await otpForm.enterCode(WRONG_CODE);
+      await otpForm.expectVisible();
+      await otpForm.expectError();
+
+      await expect.poll(status.numFailures).toBe(attempt);
+    }
+
+    // Below the threshold the correct code still logs in
+    await otpForm.enterCode(code!);
+    await loginPage.expectLoggedIn();
+  });
+
+  test('reaching the failure threshold locks the account and rejects even the correct code', async ({ page }) => {
+    const loginPage = new LoginPage(page);
+    const otpForm = new OtpForm(page);
+
+    const user = await keycloakAdmin.getUserByUsername(REALM, 'lockout-user');
+    expect(user).not.toBeNull();
+    const status = bruteForceStatusAccessors(user!.id);
+
+    // Start from a clean slate so retries and repeated runs are deterministic
+    await keycloakAdmin.clearBruteForceStatus(REALM, user!.id);
+    await expect.poll(status.numFailures).toBe(0);
+    await expect.poll(status.disabled).toBe(false);
+
+    await loginPage.goto(REALM);
+    await loginPage.login('lockout-user', TEST_PASSWORD);
+    await otpForm.expectVisible();
+
+    const email = await mailpit.waitForMessage('lockout-user@test.local');
+    const code = mailpit.extractOtpCode(email);
+    expect(code).not.toBeNull();
+
+    for (let attempt = 1; attempt <= BRUTE_FORCE_FAILURE_FACTOR; attempt++) {
+      await otpForm.enterCode(WRONG_CODE);
+      await otpForm.expectVisible();
+      await otpForm.expectError();
+    }
+
+    // The threshold is reached: the account is temporarily locked
+    await expect.poll(status.numFailures).toBeGreaterThanOrEqual(BRUTE_FORCE_FAILURE_FACTOR);
+    await expect.poll(status.disabled).toBe(true);
+
+    // Even the correct code is refused while the account is locked
+    await otpForm.enterCode(code!);
+    await otpForm.expectVisible();
+    await otpForm.expectError();
+    await expect.poll(status.disabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

Failed Email-OTP submissions are never counted by Keycloak's brute-force protection. The authenticator correctly records an `INVALID_USER_CREDENTIALS` event and returns a failure challenge, and Keycloak's flow engine does invoke brute-force registration for it - but `DefaultBruteForceProtector` only counts failures whose authentication category is one of `password`, `otp`, or `recovery-authn-codes` (`ALLOWED_AUTHENTICATION_CATEGORIES`). The factory's `getReferenceCategory()` returns `"otp-over-email"`, which is not in that list, so every failed submission is silently discarded: `numFailures` stays at 0 and lockout never engages, leaving OTP guessing unrestricted within the code lifetime even on brute-force-protected realms.

This PR changes `getReferenceCategory()` to return `OTPCredentialModel.TYPE` (`"otp"`) - the same reference category Keycloak's built-in OTP form authenticator reports - so failed submissions are counted and the realm's brute-force settings apply. The lockout *check* side already worked (`enabledUser` / `isDisabledByBruteForce`); only failure registration was broken.

Test coverage added:
- A unit assertion that the reference category is contained in `DefaultBruteForceProtector.ALLOWED_AUTHENTICATION_CATEGORIES` - the exact invariant whose violation caused the bug.
- A new e2e realm (`test-brute-force`, brute force enabled, `failureFactor` 3) and `brute-force.spec.ts` verifying via the attack-detection admin API that each wrong submission increments `numFailures`, that reaching the threshold temporarily locks the account, and that even the correct code is refused while locked. Attack-detection state is cleared at test start so CI retries are deterministic, and counter reads poll since the protector counts on a background worker.

## Related Issue

Fixes #85

## Checklist

- [x] Code is tested and works as expected.
- [x] Documentation is updated (if applicable). - no documentation changes needed
- [x] No linting or formatting issues.

## Screenshots (if applicable)

Not applicable - server-side behaviour change only.

## Additional Notes

- Verified in both directions: full suite passes with the fix (283 unit / 44 e2e); with the fix temporarily reverted, exactly the two new brute-force tests fail (counter stuck at 0, no lockout) while the other 42 still pass.
- Behavioral note: the category change is also visible as the "reference" value in the admin console's flow view, now aligning with the built-in OTP form. Failures under the `otp` category additionally feed Keycloak's secondary-auth counter, which only has an effect when a realm configures `maxSecondaryAuthFailures`.
