### PR TITLE
fix(conditional): only guard against null user when the authenticator requires one

### DIFF
--- a/src/main/java/ch/jacem/for_keycloak/email_otp_authenticator/authentication/authenticators/conditional/CustomConditionalUserConfiguredAuthenticator.java
+++ b/src/main/java/ch/jacem/for_keycloak/email_otp_authenticator/authentication/authenticators/conditional/CustomConditionalUserConfiguredAuthenticator.java
@@ -67,8 +67,12 @@ public class CustomConditionalUserConfiguredAuthenticator extends ConditionalUse
             return ((AcceptsFullContextInConfiguredFor) authenticator).configuredFor(context, config);
         }
 
-        // Guard against null user - can happen before authentication completes
-        if (context.getUser() == null) {
+        // Guard against null user - only when the authenticator actually requires one,
+        // matching Keycloak's built-in ConditionalUserConfiguredAuthenticator. Authenticators
+        // designed to run before a user is identified (e.g. the Organization Identity-First
+        // Login) must still be evaluated, otherwise conditional subflows wrapping them are
+        // silently disabled at first render.
+        if (authenticator.requiresUser() && context.getUser() == null) {
             return false;
         }
 

--- a/src/test/java/ch/jacem/for_keycloak/email_otp_authenticator/authentication/authenticators/conditional/CustomConditionalUserConfiguredAuthenticatorTest.java
+++ b/src/test/java/ch/jacem/for_keycloak/email_otp_authenticator/authentication/authenticators/conditional/CustomConditionalUserConfiguredAuthenticatorTest.java
@@ -1,0 +1,100 @@
+package ch.jacem.for_keycloak.email_otp_authenticator.authentication.authenticators.conditional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+
+@DisplayName("CustomConditionalUserConfiguredAuthenticator")
+class CustomConditionalUserConfiguredAuthenticatorTest {
+
+    private static final String FLOW_ID = "flow-id";
+    private static final String CONDITION_EXECUTION_ID = "condition-execution-id";
+    private static final String TARGET_EXECUTION_ID = "target-execution-id";
+    private static final String TARGET_PROVIDER_ID = "some-authenticator";
+
+    private AuthenticationFlowContext context;
+    private RealmModel realm;
+    private KeycloakSession session;
+    private Authenticator targetAuthenticator;
+    private AuthenticationExecutionModel targetExecution;
+
+    @BeforeEach
+    void setUp() {
+        context = mock(AuthenticationFlowContext.class);
+        realm = mock(RealmModel.class);
+        session = mock(KeycloakSession.class);
+        KeycloakSessionFactory sessionFactory = mock(KeycloakSessionFactory.class);
+        AuthenticatorFactory targetFactory = mock(AuthenticatorFactory.class);
+        targetAuthenticator = mock(Authenticator.class);
+
+        AuthenticationExecutionModel conditionExecution = mock(AuthenticationExecutionModel.class);
+        when(conditionExecution.getParentFlow()).thenReturn(FLOW_ID);
+        when(conditionExecution.getId()).thenReturn(CONDITION_EXECUTION_ID);
+
+        targetExecution = mock(AuthenticationExecutionModel.class);
+        when(targetExecution.getId()).thenReturn(TARGET_EXECUTION_ID);
+        when(targetExecution.isAuthenticatorFlow()).thenReturn(false);
+        when(targetExecution.getAuthenticator()).thenReturn(TARGET_PROVIDER_ID);
+        when(targetExecution.isRequired()).thenReturn(false);
+        when(targetExecution.isAlternative()).thenReturn(true);
+
+        when(context.getExecution()).thenReturn(conditionExecution);
+        when(context.getRealm()).thenReturn(realm);
+        when(context.getSession()).thenReturn(session);
+        when(realm.getAuthenticationExecutionsStream(FLOW_ID))
+                .thenAnswer(invocation -> Stream.of(targetExecution));
+        when(session.getKeycloakSessionFactory()).thenReturn(sessionFactory);
+        when(sessionFactory.getProviderFactory(eq(Authenticator.class), eq(TARGET_PROVIDER_ID)))
+                .thenReturn(targetFactory);
+        when(targetFactory.create(session)).thenReturn(targetAuthenticator);
+    }
+
+    @Test
+    @DisplayName("matches when no user is set yet but the authenticator does not require one")
+    void matchesWithoutUserWhenAuthenticatorDoesNotRequireUser() {
+        // e.g. the Organization Identity-First Login authenticator: requiresUser() == false,
+        // configuredFor() == realm.isOrganizationsEnabled(). It is designed to be evaluated
+        // before any user is identified.
+        when(context.getUser()).thenReturn(null);
+        when(targetAuthenticator.requiresUser()).thenReturn(false);
+        when(targetAuthenticator.configuredFor(eq(session), eq(realm), any())).thenReturn(true);
+
+        assertTrue(CustomConditionalUserConfiguredAuthenticator.SINGLETON.matchCondition(context));
+    }
+
+    @Test
+    @DisplayName("does not match when no user is set yet and the authenticator requires one")
+    void doesNotMatchWithoutUserWhenAuthenticatorRequiresUser() {
+        when(context.getUser()).thenReturn(null);
+        when(targetAuthenticator.requiresUser()).thenReturn(true);
+
+        assertFalse(CustomConditionalUserConfiguredAuthenticator.SINGLETON.matchCondition(context));
+        verify(targetAuthenticator, never()).configuredFor(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("delegates to configuredFor when a user is set")
+    void delegatesToConfiguredForWhenUserIsSet() {
+        UserModel user = mock(UserModel.class);
+        when(context.getUser()).thenReturn(user);
+        when(targetAuthenticator.requiresUser()).thenReturn(true);
+        when(targetAuthenticator.configuredFor(session, realm, user)).thenReturn(true);
+
+        assertTrue(CustomConditionalUserConfiguredAuthenticator.SINGLETON.matchCondition(context));
+    }
+}


### PR DESCRIPTION
Fixes #102.

## Problem

Since v1.2.0, `CustomConditionalUserConfiguredAuthenticator.isConfiguredFor()` returns `false` whenever `context.getUser() == null`. Because this SPI registers under the same provider id as Keycloak's built-in `conditional-user-configured`, it replaces the built-in behavior for **every** conditional subflow in every realm.

Authenticators designed to run before a user is identified — notably the `Organization Identity-First Login` (`organization`), whose `requiresUser()` is `false` and whose `configuredFor()` returns `realm.isOrganizationsEnabled()` — are then never evaluated: the conditional subflow wrapping them goes `EVALUATED_FALSE` at first render and organization identity-first login (org-domain IdP redirects) silently stops working. Reproduced on Keycloak 26.2.5 and 26.5.7 with v1.4.3, working on both with v1.1.4 (full matrix in #102).

## Fix

Align the guard with Keycloak's built-in [`ConditionalUserConfiguredAuthenticator`](https://github.com/keycloak/keycloak/blob/26.5.7/services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalUserConfiguredAuthenticator.java):

```java
if (authenticator.requiresUser() && context.getUser() == null) {
    return false;
}
```

The `AcceptsFullContextInConfiguredFor` path above it is untouched, so the Email OTP form's own role-based conditional evaluation keeps working exactly as before.

## Tests

Added `CustomConditionalUserConfiguredAuthenticatorTest` covering:
- no user + `requiresUser() == false` → condition matches (the organization-authenticator scenario)
- no user + `requiresUser() == true` → condition does not match, `configuredFor` never called (preserves the v1.2.0 null-safety intent)
- user present → delegates to `configuredFor`

`mvn test -DskipTests=false`: 287 tests, 0 failures (284 existing + 3 new).

Also verified end-to-end in a Zenchef staging image: with this patched jar on Keycloak 26.5.7, the org identity-first flow works again and the email OTP flow (send, reject wrong code, accept correct code) is unaffected.