### PR TITLE
feat(keycloak): add 26.7.3 build profile (new default)

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -33,6 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         keycloak_version:
+          - keycloak-26.7.2
           - keycloak-26.6.2
           - keycloak-26.5.7
           - keycloak-26.4.7

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         keycloak_version:
-          - keycloak-26.7.2
+          - keycloak-26.7.3
           - keycloak-26.6.2
           - keycloak-26.5.7
           - keycloak-26.4.7

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,6 +41,7 @@ jobs:
           - '26.3.5'
           - '26.4.7'
           - '26.5.7'
+          - '26.7.2'
           - '26.6.2'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,7 +41,7 @@ jobs:
           - '26.3.5'
           - '26.4.7'
           - '26.5.7'
-          - '26.7.2'
+          - '26.7.3'
           - '26.6.2'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Add the following to your Dockerfile:
 ```dockerfile
 # Download and install the authenticator
 ARG EMAIL_OTP_AUTHENTICATOR_VERSION="v1.4.3" # x-release-please-version
-ARG EMAIL_OTP_AUTHENTICATOR_KC_VERSION="26.7.2"
+ARG EMAIL_OTP_AUTHENTICATOR_KC_VERSION="26.7.3"
 ADD https://github.com/for-keycloak/email-otp-authenticator/releases/download/${EMAIL_OTP_AUTHENTICATOR_VERSION}/email-otp-authenticator-${EMAIL_OTP_AUTHENTICATOR_VERSION}-kc-${EMAIL_OTP_AUTHENTICATOR_KC_VERSION}.jar \
     /opt/keycloak/providers/email-otp-authenticator.jar
 ```
@@ -141,7 +141,7 @@ ADD https://github.com/for-keycloak/email-otp-authenticator/releases/download/${
 
 Using just:
 ```bash
-# Build for the default Keycloak version (26.7.2)
+# Build for the default Keycloak version (26.7.3)
 just build
 
 # Build for a specific Keycloak version
@@ -184,7 +184,7 @@ Access:
 
 The authenticator is built and tested with multiple Keycloak versions:
 
-- 26.7.2 (default)
+- 26.7.3 (default)
 - 26.6.2
 - 26.5.7
 - 26.4.7

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Add the following to your Dockerfile:
 ```dockerfile
 # Download and install the authenticator
 ARG EMAIL_OTP_AUTHENTICATOR_VERSION="v1.4.3" # x-release-please-version
-ARG EMAIL_OTP_AUTHENTICATOR_KC_VERSION="26.6.2"
+ARG EMAIL_OTP_AUTHENTICATOR_KC_VERSION="26.7.2"
 ADD https://github.com/for-keycloak/email-otp-authenticator/releases/download/${EMAIL_OTP_AUTHENTICATOR_VERSION}/email-otp-authenticator-${EMAIL_OTP_AUTHENTICATOR_VERSION}-kc-${EMAIL_OTP_AUTHENTICATOR_KC_VERSION}.jar \
     /opt/keycloak/providers/email-otp-authenticator.jar
 ```
@@ -141,7 +141,7 @@ ADD https://github.com/for-keycloak/email-otp-authenticator/releases/download/${
 
 Using just:
 ```bash
-# Build for the default Keycloak version (26.6.2)
+# Build for the default Keycloak version (26.7.2)
 just build
 
 # Build for a specific Keycloak version
@@ -184,7 +184,8 @@ Access:
 
 The authenticator is built and tested with multiple Keycloak versions:
 
-- 26.6.2 (default)
+- 26.7.2 (default)
+- 26.6.2
 - 26.5.7
 - 26.4.7
 - 26.3.5

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   keycloak:
-    image: quay.io/keycloak/keycloak:26.7.2
+    image: quay.io/keycloak/keycloak:26.7.3
     environment:
       # Admin console credentials
       KEYCLOAK_ADMIN: admin
@@ -19,7 +19,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ./target/email-otp-authenticator-dev-kc-26.7.2.jar:/opt/keycloak/providers/email-otp-authenticator.jar
+      - ./target/email-otp-authenticator-dev-kc-26.7.3.jar:/opt/keycloak/providers/email-otp-authenticator.jar
     command: start-dev
     depends_on:
       - mailpit

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   keycloak:
-    image: quay.io/keycloak/keycloak:26.6.2
+    image: quay.io/keycloak/keycloak:26.7.2
     environment:
       # Admin console credentials
       KEYCLOAK_ADMIN: admin
@@ -19,7 +19,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ./target/email-otp-authenticator-dev-kc-26.6.2.jar:/opt/keycloak/providers/email-otp-authenticator.jar
+      - ./target/email-otp-authenticator-dev-kc-26.7.2.jar:/opt/keycloak/providers/email-otp-authenticator.jar
     command: start-dev
     depends_on:
       - mailpit

--- a/justfile
+++ b/justfile
@@ -44,14 +44,15 @@ shell:
 # List all available Keycloak versions
 versions:
     @echo "Supported Keycloak versions:"
-    @echo "- 26.6.2 (default)"
+    @echo "- 26.7.2 (default)"
+    @echo "- 26.6.2"
     @echo "- 26.5.7"
     @echo "- 26.4.7"
     @echo "- 26.3.5"
     @echo "- 26.2.5"
 
 # Run E2E tests (optionally specify a file pattern, requires test-e2e-setup if FILE is provided)
-test-e2e KC_VERSION="26.6.2" FILE="": (build-version KC_VERSION)
+test-e2e KC_VERSION="26.7.2" FILE="": (build-version KC_VERSION)
     #!/usr/bin/env bash
     cd tests/e2e
     if [ -z "{{FILE}}" ]; then
@@ -63,7 +64,7 @@ test-e2e KC_VERSION="26.6.2" FILE="": (build-version KC_VERSION)
     fi
 
 # Start test infrastructure only (for debugging or running specific tests)
-test-e2e-setup KC_VERSION="26.6.2": (build-version KC_VERSION)
+test-e2e-setup KC_VERSION="26.7.2": (build-version KC_VERSION)
     cd tests/e2e && KC_VERSION={{KC_VERSION}} docker compose up -d --wait
 
 # Stop test containers

--- a/justfile
+++ b/justfile
@@ -44,7 +44,7 @@ shell:
 # List all available Keycloak versions
 versions:
     @echo "Supported Keycloak versions:"
-    @echo "- 26.7.2 (default)"
+    @echo "- 26.7.3 (default)"
     @echo "- 26.6.2"
     @echo "- 26.5.7"
     @echo "- 26.4.7"
@@ -52,7 +52,7 @@ versions:
     @echo "- 26.2.5"
 
 # Run E2E tests (optionally specify a file pattern, requires test-e2e-setup if FILE is provided)
-test-e2e KC_VERSION="26.7.2" FILE="": (build-version KC_VERSION)
+test-e2e KC_VERSION="26.7.3" FILE="": (build-version KC_VERSION)
     #!/usr/bin/env bash
     cd tests/e2e
     if [ -z "{{FILE}}" ]; then
@@ -64,7 +64,7 @@ test-e2e KC_VERSION="26.7.2" FILE="": (build-version KC_VERSION)
     fi
 
 # Start test infrastructure only (for debugging or running specific tests)
-test-e2e-setup KC_VERSION="26.7.2": (build-version KC_VERSION)
+test-e2e-setup KC_VERSION="26.7.3": (build-version KC_VERSION)
     cd tests/e2e && KC_VERSION={{KC_VERSION}} docker compose up -d --wait
 
 # Stop test containers

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <skipTests>true</skipTests>
 
         <!-- Default Keycloak version -->
-        <keycloak.version>26.6.2</keycloak.version>
+        <keycloak.version>26.7.2</keycloak.version>
 
         <!-- Dependency versions -->
         <jakarta.ws.rs-api.version>4.0.0</jakarta.ws.rs-api.version>
@@ -59,9 +59,37 @@
     <!-- Profiles for different Keycloak versions -->
     <profiles>
         <profile>
+            <id>keycloak-26.7.2</id>
+            <properties><keycloak.version>26.7.2</keycloak.version></properties>
+            <activation><activeByDefault>true</activeByDefault></activation>
+            <!-- Tests that depend on Keycloak 26.6+ APIs (e.g. DefaultBruteForceProtector.ALLOWED_AUTHENTICATION_CATEGORIES) live here and are only compiled on 26.6+ builds. -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>${build-helper-maven-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>add-kc26_6-test-source</id>
+                                <phase>generate-test-sources</phase>
+                                <goals>
+                                    <goal>add-test-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>src/test/java-kc26_6</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>keycloak-26.6.2</id>
             <properties><keycloak.version>26.6.2</keycloak.version></properties>
-            <activation><activeByDefault>true</activeByDefault></activation>
             <!-- Tests that depend on Keycloak 26.6+ APIs (e.g. DefaultBruteForceProtector.ALLOWED_AUTHENTICATION_CATEGORIES) live here and are only compiled on 26.6+ builds. -->
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <skipTests>true</skipTests>
 
         <!-- Default Keycloak version -->
-        <keycloak.version>26.7.2</keycloak.version>
+        <keycloak.version>26.7.3</keycloak.version>
 
         <!-- Dependency versions -->
         <jakarta.ws.rs-api.version>4.0.0</jakarta.ws.rs-api.version>
@@ -59,8 +59,8 @@
     <!-- Profiles for different Keycloak versions -->
     <profiles>
         <profile>
-            <id>keycloak-26.7.2</id>
-            <properties><keycloak.version>26.7.2</keycloak.version></properties>
+            <id>keycloak-26.7.3</id>
+            <properties><keycloak.version>26.7.3</keycloak.version></properties>
             <activation><activeByDefault>true</activeByDefault></activation>
             <!-- Tests that depend on Keycloak 26.6+ APIs (e.g. DefaultBruteForceProtector.ALLOWED_AUTHENTICATION_CATEGORIES) live here and are only compiled on 26.6+ builds. -->
             <build>

--- a/tests/e2e/docker-compose.yaml
+++ b/tests/e2e/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       - test
 
   keycloak:
-    image: quay.io/keycloak/keycloak:${KC_VERSION:-26.7.2}
+    image: quay.io/keycloak/keycloak:${KC_VERSION:-26.7.3}
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
@@ -35,7 +35,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ../../target/email-otp-authenticator-dev-kc-${KC_VERSION:-26.7.2}.jar:/opt/keycloak/providers/email-otp-authenticator.jar
+      - ../../target/email-otp-authenticator-dev-kc-${KC_VERSION:-26.7.3}.jar:/opt/keycloak/providers/email-otp-authenticator.jar
     command: start-dev
     depends_on:
       postgres:

--- a/tests/e2e/docker-compose.yaml
+++ b/tests/e2e/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       - test
 
   keycloak:
-    image: quay.io/keycloak/keycloak:${KC_VERSION:-26.6.2}
+    image: quay.io/keycloak/keycloak:${KC_VERSION:-26.7.2}
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
@@ -35,7 +35,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ../../target/email-otp-authenticator-dev-kc-${KC_VERSION:-26.6.2}.jar:/opt/keycloak/providers/email-otp-authenticator.jar
+      - ../../target/email-otp-authenticator-dev-kc-${KC_VERSION:-26.7.2}.jar:/opt/keycloak/providers/email-otp-authenticator.jar
     command: start-dev
     depends_on:
       postgres:


### PR DESCRIPTION
Closes #103.

## Changes

Follows the pattern of ef67325 (which added 26.6.2 as default):

- `pom.xml`: new `keycloak-26.7.3` profile, now `activeByDefault`; it carries the same `kc26_6` extra test-source block as 26.6.2 since the 26.6+ APIs (`DefaultBruteForceProtector.ALLOWED_AUTHENTICATION_CATEGORIES`) are still present in 26.7. The `keycloak-26.6.2` profile stays, just no longer default.
- `tests.yaml` / `release-please.yaml`: `26.7.3` added to the matrices (26.2.5 → 26.7.3 now covered).
- `docker-compose.yaml`, `tests/e2e/docker-compose.yaml`, `justfile`, `README.md`: default version references bumped 26.6.2 → 26.7.3 (26.6.2 kept in the supported-versions lists).

## Verification

- `mvn test -DskipTests=false` against 26.7.3: **284 tests, 0 failures** (incl. the kc26_6 brute-force test source)
- `mvn clean package` produces `email-otp-authenticator-dev-kc-26.7.3.jar` (default) and `-kc-26.6.2.jar` (`-P keycloak-26.6.2`)

Note: consumers currently pinned to v1.1.4 because of #102 will want a release that contains both #104 and this, so they can jump straight to a fixed 26.7-compatible version.